### PR TITLE
Fixed some errors in build: wxWidgets and rtlsdr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ wxWidgets: build_stage install_dir install_dir/wxWidgets-staticlib/bin/wx-config
 install_dir/wxWidgets-staticlib/bin/wx-config:
 	cd build_stage && wget https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.1/wxWidgets-3.2.1.tar.bz2 
 	cd build_stage && tar -xvjf wxWidgets-3.2.1.tar.bz2
-	cd build_stage/wxWidgets-3.2.1 && ./configure --with-opengl --with-libjpeg --disable-shared --enable-monolithic --with-libtiff --with-libpng --with-zlib --disable-sdltest --enable-unicode --enable-display --enable-propgrid --disable-webview --disable-webviewwebkit --prefix=${INSTALL_DIR}/wxWidgets-staticlib CXXFLAGS="-std=c++0x"
+	patch < wxWidgets_pngpriv_macos_15-4.patch
+	cd build_stage/wxWidgets-3.2.1 && ./configure --with-opengl --with-libjpeg --disable-shared --enable-monolithic --with-libtiff=builtin --with-libpng --with-zlib --disable-sdltest --enable-unicode --enable-display --enable-propgrid --disable-webview --disable-webviewwebkit --prefix=${INSTALL_DIR}/wxWidgets-staticlib CXXFLAGS="-std=c++0x"
 	cd build_stage/wxWidgets-3.2.1 && make -j${NPROC} && make install
 
 liquid-dsp: build_stage install_dir install_dir/lib/libliquid.dylib
@@ -62,7 +63,7 @@ nodep_modules: SoapySDRPlay
 
 librtlsdr: build_stage install_dir install_dir/lib/librtlsdr.dylib
 install_dir/lib/librtlsdr.dylib:
-	$(call BUILD_AND_INSTALL,rtlsdr,https://github.com/rtlsdrblog/rtl-sdr-blog.git,-DLIBUSB_INCLUDE_DIRS=/usr/local/include/libusb-1.0/ -DLIBUSB_LIBRARIES=/usr/local/lib/libusb-1.0.dylib)
+	$(call BUILD_AND_INSTALL,rtlsdr,https://github.com/rtlsdrblog/rtl-sdr-blog.git,-DLIBUSB_INCLUDE_DIRS=/opt/homebrew/Cellar/libusb/1.0.29/include/libusb-1.0 -DLIBUSB_LIBRARIES=/opt/homebrew/Cellar/libusb/1.0.29/lib/libusb-1.0.dylib)
 
 SoapyRTLSDR: SoapySDR $(SOAPY_MOD_PATH)/librtlsdrSupport.so
 $(SOAPY_MOD_PATH)/librtlsdrSupport.so: librtlsdr

--- a/wxWidgets_pngpriv_macos_15-4.patch
+++ b/wxWidgets_pngpriv_macos_15-4.patch
@@ -1,0 +1,21 @@
+--- build_stage/wxWidgets-3.2.1/src/png/pngpriv.h	2022-03-20 15:58:34
++++ build_stage/wxWidgets-3.2.1/src/png/pngpriv.h	2022-03-20 15:58:34
+@@ -526,18 +526,7 @@
+     */
+ #  include <float.h>
+
+-#  if (defined(__MWERKS__) && defined(macintosh)) || defined(applec) || \
+-    defined(THINK_C) || defined(__SC__) || defined(TARGET_OS_MAC)
+-   /* We need to check that <math.h> hasn't already been included earlier
+-    * as it seems it doesn't agree with <fp.h>, yet we should really use
+-    * <fp.h> if possible.
+-    */
+-#    if !defined(__MATH_H__) && !defined(__MATH_H) && !defined(__cmath__)
+-#      include <fp.h>
+-#    endif
+-#  else
+ #    include <math.h>
+-#  endif
+ #  if defined(_AMIGA) && defined(__SASC) && defined(_M68881)
+    /* Amiga SAS/C: We must include builtin FPU functions when compiling using
+     * MATH=68881


### PR DESCRIPTION
wxWidgets failed on not being able to find `fp.h` and `libtiff`.
rtlsdr couldn't find the brew installed `libusb.h`

Fixed it with

*  a patch for wxWidgets pngpriv.h
* using `--with-libtiff=builtin` instead of `--with-libtiff` in configuring wxWidgets
* changing the path to (a specific (couldn't find a more 'generic' path)) libusb (`-DLIBUSB_INCLUDE_DIRS` and `-DLIBUSB_LIBRARIES`

Now the build completes succesfully.

Mind you, unfortunately, the resulting application crashes immediately, see: [here](https://github.com/cjcliffe/CubicSDR-macOSBuild/issues/6)